### PR TITLE
change session ID from UUID to sequential integers

### DIFF
--- a/mcp_ols.py
+++ b/mcp_ols.py
@@ -1,5 +1,4 @@
 import io
-import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -27,9 +26,11 @@ sns.set_style("whitegrid")
 class DataAnalysisSession:
     def __init__(self):
         self.sessions: dict[str, dict[str, Any]] = {}
+        self._next_id = 1
 
     def create_session(self) -> str:
-        session_id = str(uuid.uuid4())
+        session_id = str(self._next_id)
+        self._next_id += 1
         self.sessions[session_id] = {
             "data": None,
             "metadata": {},
@@ -49,11 +50,12 @@ _session = DataAnalysisSession()
 
 
 @mcp.tool(exclude_args=["server_session"])
-def create_analysis_session(server_session=None) -> str:
+def create_analysis_session(server_session=None):
     """Create a new analysis session"""
     if server_session is None:
         server_session = _session
-    return server_session.create_session()
+    session_id = server_session.create_session()
+    return {"session_id": session_id}
 
 
 @mcp.tool(exclude_args=["server_session"])

--- a/test_mcp_server.py
+++ b/test_mcp_server.py
@@ -39,12 +39,12 @@ async def test_session_creation():
     """Test creating analysis sessions"""
     async with Client(mcp) as client:
         result = await client.call_tool("create_analysis_session", {})
-        session_id = result[0].text
+        session_id = json.loads(result[0].text)["session_id"]
         assert isinstance(session_id, str)
         assert len(session_id) > 0
 
         result2 = await client.call_tool("create_analysis_session", {})
-        session_id2 = result2[0].text
+        session_id2 = json.loads(result2[0].text)["session_id"]
         assert session_id != session_id2
 
 
@@ -53,7 +53,7 @@ async def test_data_loading(sample_csv_data):
     """Test loading data from CSV files"""
     async with Client(mcp) as client:
         result = await client.call_tool("create_analysis_session", {})
-        session_id = result[0].text
+        session_id = json.loads(result[0].text)["session_id"]
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             f.write(sample_csv_data)
@@ -77,7 +77,7 @@ async def test_data_loading_errors():
     """Test error handling in data loading"""
     async with Client(mcp) as client:
         result = await client.call_tool("create_analysis_session", {})
-        session_id = result[0].text
+        session_id = json.loads(result[0].text)["session_id"]
 
         # Test nonexistent file
         with pytest.raises(ToolError):
@@ -99,7 +99,7 @@ async def test_ols_regression(sample_csv_data):
     """Test OLS regression functionality"""
     async with Client(mcp) as client:
         result = await client.call_tool("create_analysis_session", {})
-        session_id = result[0].text
+        session_id = json.loads(result[0].text)["session_id"]
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             f.write(sample_csv_data)
@@ -143,7 +143,7 @@ async def test_logistic_regression(sample_logistic_data):
     """Test logistic regression functionality"""
     async with Client(mcp) as client:
         result = await client.call_tool("create_analysis_session", {})
-        session_id = result[0].text
+        session_id = json.loads(result[0].text)["session_id"]
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             f.write(sample_logistic_data)
@@ -174,7 +174,7 @@ async def test_model_diagnostics(sample_csv_data):
     """Test model diagnostic functionality"""
     async with Client(mcp) as client:
         result = await client.call_tool("create_analysis_session", {})
-        session_id = result[0].text
+        session_id = json.loads(result[0].text)["session_id"]
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             f.write(sample_csv_data)
@@ -235,7 +235,7 @@ async def test_model_comparison(sample_csv_data):
     """Test model comparison functionality"""
     async with Client(mcp) as client:
         result = await client.call_tool("create_analysis_session", {})
-        session_id = result[0].text
+        session_id = json.loads(result[0].text)["session_id"]
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             f.write(sample_csv_data)
@@ -291,7 +291,7 @@ async def test_partial_dependence_plots(sample_csv_data):
     """Test partial dependence plot functionality"""
     async with Client(mcp) as client:
         result = await client.call_tool("create_analysis_session", {})
-        session_id = result[0].text
+        session_id = json.loads(result[0].text)["session_id"]
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             f.write(sample_csv_data)


### PR DESCRIPTION
UUIDs have high entropy, so LLMs often miss them.
Since this is a local-first tool, a sequential integer ID should work just as well and be much more friendly for LLMs when performing tool calls.